### PR TITLE
[Fix] Remove sensitive server headers

### DIFF
--- a/docker/sail/7.4/php.ini
+++ b/docker/sail/7.4/php.ini
@@ -2,3 +2,4 @@
 post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
+expose_php = Off

--- a/docker/sail/8.0/php.ini
+++ b/docker/sail/8.0/php.ini
@@ -2,3 +2,4 @@
 post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
+expose_php = Off

--- a/docker/sail/8.1/php.ini
+++ b/docker/sail/8.1/php.ini
@@ -2,3 +2,4 @@
 post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
+expose_php = Off

--- a/public/.user.ini
+++ b/public/.user.ini
@@ -1,2 +1,3 @@
 post_max_size = 20M
 upload_max_filesize = 10M
+expose_php = Off


### PR DESCRIPTION
### Proposed changes

- Sets `expose_php` in `php.ini` to `Off`; which disables the `X-Powered-By` header.