### PR TITLE
[Fix] Make farmland block be seen on edit screen only

### DIFF
--- a/app/Orchid/Screens/Batch/BatchEditScreen.php
+++ b/app/Orchid/Screens/Batch/BatchEditScreen.php
@@ -59,7 +59,8 @@ class BatchEditScreen extends AnikulturaEditScreen
                     ->description(__('The assigned site location of this batch')),
                 Layout::block(BatchEditFarmlandLayout::class)
                     ->title(__('Batch Farmlands'))
-                    ->description(__('The farmlands who belong to this batch')),
+                    ->description(__('The farmlands who belong to this batch'))
+                    ->canSee($this->exists()),
                 Layout::block(BatchEditFarmersLayout::class)
                     ->title(__('Batch Farmers'))
                     ->description(__('The farmers who belong to this batch'))


### PR DESCRIPTION
### Proposed changes

- See commits.
