### PR TITLE
[Fix] Fix farmland batch integrity and delete user bug

### DIFF
--- a/app/Actions/Batch/CreateBatch.php
+++ b/app/Actions/Batch/CreateBatch.php
@@ -20,13 +20,11 @@ class CreateBatch
             ->fill($batchData)
             ->save();
 
-        $farmers = $batchData['farmers'];
-
         $batch
             ->farmers()
-            ->sync($farmers);
+            ->sync($batchData['farmers']);
 
-        return $batch;
+        return $batch->refresh();
     }
 
     public function asOrchidAction(mixed $model, ?Request $request): RedirectResponse

--- a/app/Actions/Crop/Api/RetrieveCurrentSeedStage.php
+++ b/app/Actions/Crop/Api/RetrieveCurrentSeedStage.php
@@ -32,12 +32,7 @@ class RetrieveCurrentSeedStage
         Farmer $farmer,
         Farmland $farmland
     ): void {
-        $query = Farmer::query()->whereHas(
-            'farmlands',
-            fn ($q) => $q->where('id', $farmland->id)
-        );
-
-        $farmer = $query->find($farmer->id);
+        $farmer = Farmer::ofFarmland($farmland)->find($farmer->id);
 
         if (is_null($farmer)) {
             throw new Exception('Farmer does not belong to farmland');

--- a/app/Actions/Farmland/CreateFarmland.php
+++ b/app/Actions/Farmland/CreateFarmland.php
@@ -56,7 +56,15 @@ class CreateFarmland
     {
         $farmlandData = $request->get('farmland');
 
-        $this->handle($model, $farmlandData);
+        try {
+            $this->handle($model, $farmlandData);
+        } catch (Exception $exception) {
+            Toast::error($exception->getMessage());
+
+            return redirect()->route('platform.farmlands.edit', [
+                $model->id,
+            ]);
+        }
 
         Toast::info(__('Farmland was saved successfully!'));
 

--- a/app/Actions/Farmland/CreateFarmland.php
+++ b/app/Actions/Farmland/CreateFarmland.php
@@ -72,6 +72,11 @@ class CreateFarmland
                 'min:3',
                 'max:70',
             ],
+            'farmland.batch_id' => [
+                'required',
+                'integer',
+                'exists:batches,id',
+            ],
             'farmland.type_id' => [
                 'required',
                 'integer',

--- a/app/Actions/User/Admin/DeleteAdmin.php
+++ b/app/Actions/User/Admin/DeleteAdmin.php
@@ -18,9 +18,9 @@ class DeleteAdmin
 
     public function handle(Admin $admin): bool
     {
-        $admin->profile->delete();
+        $admin->delete();
 
-        return $admin->delete();
+        return $admin->profile->delete();
     }
 
     public function asOrchidAction(mixed $model, ?Request $request): RedirectResponse

--- a/app/Actions/User/BigBrother/DeleteBigBrother.php
+++ b/app/Actions/User/BigBrother/DeleteBigBrother.php
@@ -18,9 +18,9 @@ class DeleteBigBrother
 
     public function handle(BigBrother $bigBrother): bool
     {
-        $bigBrother->profile->delete();
+        $bigBrother->delete();
 
-        return $bigBrother->delete();
+        return $bigBrother->profile->delete();
     }
 
     public function asOrchidAction(mixed $model, ?Request $request): RedirectResponse

--- a/app/Actions/User/Farmer/DeleteFarmer.php
+++ b/app/Actions/User/Farmer/DeleteFarmer.php
@@ -18,9 +18,9 @@ class DeleteFarmer
 
     public function handle(Farmer $farmer): bool
     {
-        $farmer->profile->delete();
+        $farmer->delete();
 
-        return $farmer->delete();
+        return $farmer->profile->delete();
     }
 
     public function asOrchidAction(mixed $model, ?Request $request): RedirectResponse

--- a/app/Models/Farmland/Farmland.php
+++ b/app/Models/Farmland/Farmland.php
@@ -66,11 +66,12 @@ class Farmland extends Model
         return "{$this->name} - {$farmlandSchoolName}";
     }
 
-    public function scopeFarmerBelongToFarmland(Builder $query, $farmerId)
+    public function scopeOfFarmer(Builder $query, Farmer $farmer): Builder
     {
-        return $query->whereHas('farmers', function ($q) use ($farmerId) {
-            $q->whereIn('id', [$farmerId]);
-        });
+        return $query->whereHas(
+            'farmers',
+            fn (Builder $query) => $query->whereIn('id', [$farmer->id])
+        );
     }
 
     /**

--- a/app/Models/User/Farmer/Farmer.php
+++ b/app/Models/User/Farmer/Farmer.php
@@ -36,6 +36,14 @@ class Farmer extends User
         );
     }
 
+    public function scopeOfFarmland(Builder $query, Farmland $farmland): Builder
+    {
+        return $query->whereHas(
+            'farmlands',
+            fn (Builder $query) => $query->where('id', '=', $farmland->id)
+        );
+    }
+
     public function batches(): BelongsToMany
     {
         return $this->belongsToMany(Batch::class, 'batch_farmers', 'farmer_id', 'batch_id');

--- a/app/Models/User/Farmer/Farmer.php
+++ b/app/Models/User/Farmer/Farmer.php
@@ -28,11 +28,12 @@ class Farmer extends User
         });
     }
 
-    public function scopeFarmerBelongToBatch(Builder $query, $batchId)
+    public function scopeOfBatch(Builder $query, Batch $batch): Builder
     {
-        return $query->whereHas('batches', function ($q) use ($batchId) {
-            $q->where('id', '=', $batchId);
-        });
+        return $query->whereHas(
+            'batches',
+            fn (Builder $query) => $query->where('id', '=', $batch->id)
+        );
     }
 
     public function batches(): BelongsToMany

--- a/app/Orchid/Layouts/Batch/BatchEditMemberLayout.php
+++ b/app/Orchid/Layouts/Batch/BatchEditMemberLayout.php
@@ -6,7 +6,7 @@ use App\Models\User\Farmer\Farmer;
 use App\Orchid\Layouts\AnikulturaEditLayout;
 use Orchid\Screen\Fields\Relation;
 
-class BatchEditFarmersLayout extends AnikulturaEditLayout
+class BatchEditMemberLayout extends AnikulturaEditLayout
 {
     protected function fields(): iterable
     {

--- a/app/Orchid/Layouts/Batch/BatchEditSiteLayout.php
+++ b/app/Orchid/Layouts/Batch/BatchEditSiteLayout.php
@@ -31,8 +31,8 @@ class BatchEditSiteLayout extends AnikulturaEditLayout
                 Relation::make('batch.municity_id')
                     ->fromModel(Municity::class, 'name')
                     ->required()
-                    ->title('Municity')
-                    ->placeholder(__('Municity')),
+                    ->title('Municipality or City')
+                    ->placeholder(__('Municipality or City')),
                 Input::make('batch.barangay')
                     ->type('text')
                     ->max(255)

--- a/app/Orchid/Layouts/Batch/BatchListLayout.php
+++ b/app/Orchid/Layouts/Batch/BatchListLayout.php
@@ -36,7 +36,7 @@ class BatchListLayout extends AnikulturaListLayout
                     return Link::make($batch->province->name)
                         ->route('platform.batches.edit', [$batch->id]);
                 }),
-            TD::make('municity', __('Municity'))
+            TD::make('municity', __('Municipality or City'))
                 ->sort()
                 ->render(function (Batch $batch) {
                     return Link::make($batch->municity->name)

--- a/app/Orchid/Layouts/FarmerReport/FarmerReportEditInfoLayout.php
+++ b/app/Orchid/Layouts/FarmerReport/FarmerReportEditInfoLayout.php
@@ -29,7 +29,7 @@ class FarmerReportEditInfoLayout extends AnikulturaEditLayout
 
         if ($isEditScreen) {
             $isHarvested = $currentReport->isHarvested();
-            $farmlandRelationField->applyScope('farmerBelongToFarmland', $currentReport->farmer->id);
+            $farmlandRelationField->applyScope('ofFarmer', $currentReport->farmer);
         }
 
         $fields = [

--- a/app/Orchid/Layouts/Farmland/FarmlandEditMemberLayout.php
+++ b/app/Orchid/Layouts/Farmland/FarmlandEditMemberLayout.php
@@ -10,11 +10,14 @@ class FarmlandEditMemberLayout extends AnikulturaEditLayout
 {
     protected function fields(): iterable
     {
+        $batch = $this->query->get('batch');
+
         return [
             Relation::make('farmland.farmers.')
                 ->fromModel(Farmer::class, 'name')
                 ->searchColumns('first_name', 'last_name')
                 ->displayAppend('full_name')
+                ->applyScope('ofBatch', $batch)
                 ->required()
                 ->multiple()
                 ->help(__('Search the name of this farmland\'s members'))

--- a/app/Orchid/Layouts/Farmland/FarmlandEditMemberListener.php
+++ b/app/Orchid/Layouts/Farmland/FarmlandEditMemberListener.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Orchid\Layouts\Farmland;
+
+use Orchid\Screen\Layouts\Listener;
+
+class FarmlandEditMemberListener extends Listener
+{
+    protected $targets = ['farmland.batch_id'];
+
+    protected $asyncMethod = 'asyncRetrieveBatch';
+
+    protected function layouts(): array
+    {
+        return [
+            FarmlandEditMemberLayout::class,
+        ];
+    }
+}

--- a/app/Orchid/Screens/Batch/BatchEditScreen.php
+++ b/app/Orchid/Screens/Batch/BatchEditScreen.php
@@ -7,9 +7,9 @@ use App\Actions\Batch\DeleteBatch;
 use App\Actions\Batch\DeleteBatchSeedAllocation;
 use App\Models\Batch\Batch;
 use App\Models\Batch\BatchSeedAllocation;
-use App\Orchid\Layouts\Batch\BatchEditFarmersLayout;
 use App\Orchid\Layouts\Batch\BatchEditFarmlandLayout;
 use App\Orchid\Layouts\Batch\BatchEditLayout;
+use App\Orchid\Layouts\Batch\BatchEditMemberLayout;
 use App\Orchid\Layouts\Batch\BatchEditSiteLayout;
 use App\Orchid\Layouts\Batch\BatchSeedAllocationCommandLayout;
 use App\Orchid\Layouts\Batch\BatchSeedAllocationListLayout;
@@ -61,7 +61,7 @@ class BatchEditScreen extends AnikulturaEditScreen
                     ->title(__('Batch Farmlands'))
                     ->description(__('The farmlands who belong to this batch'))
                     ->canSee($this->exists()),
-                Layout::block(BatchEditFarmersLayout::class)
+                Layout::block(BatchEditMemberLayout::class)
                     ->title(__('Batch Farmers'))
                     ->description(__('The farmers who belong to this batch'))
                     ->commands(

--- a/app/Orchid/Screens/Farmland/FarmlandEditScreen.php
+++ b/app/Orchid/Screens/Farmland/FarmlandEditScreen.php
@@ -4,9 +4,10 @@ namespace App\Orchid\Screens\Farmland;
 
 use App\Actions\Farmland\CreateFarmland;
 use App\Actions\Farmland\DeleteFarmland;
+use App\Models\Batch\Batch;
 use App\Models\Farmland\Farmland;
 use App\Orchid\Layouts\Farmland\FarmlandEditBasicLayout;
-use App\Orchid\Layouts\Farmland\FarmlandEditMemberLayout;
+use App\Orchid\Layouts\Farmland\FarmlandEditMemberListener;
 use App\Orchid\Layouts\Farmland\FarmlandEditOtherLayout;
 use App\Orchid\Screens\AnikulturaEditScreen;
 use Illuminate\Http\RedirectResponse;
@@ -33,6 +34,14 @@ class FarmlandEditScreen extends AnikulturaEditScreen
     {
         return [
             'farmland' => $farmland,
+            'batch' => $farmland->batch,
+        ];
+    }
+
+    public function asyncRetrieveBatch(array $farmland): array
+    {
+        return [
+            'batch' => Batch::find($farmland['batch_id']),
         ];
     }
 
@@ -45,7 +54,7 @@ class FarmlandEditScreen extends AnikulturaEditScreen
                     ->title(__('Basic Information'))
                     ->description(__('This information collects farmlands basic information')),
 
-                Layout::block(FarmlandEditMemberLayout::class)
+                Layout::block(FarmlandEditMemberListener::class)
                     ->title(__('Farmers'))
                     ->description(__('This information assigns the farmers to this farmland'))
                     ->commands(

--- a/app/Orchid/Screens/Farmland/FarmlandEditScreen.php
+++ b/app/Orchid/Screens/Farmland/FarmlandEditScreen.php
@@ -38,24 +38,38 @@ class FarmlandEditScreen extends AnikulturaEditScreen
 
     public function layout(): iterable
     {
+        $tabs = [
+            __('Basic Information') => [
+
+                Layout::block(FarmlandEditBasicLayout::class)
+                    ->title(__('Basic Information'))
+                    ->description(__('This information collects farmlands basic information')),
+
+                Layout::block(FarmlandEditMemberLayout::class)
+                    ->title(__('Farmers'))
+                    ->description(__('This information assigns the farmers to this farmland'))
+                    ->commands(
+                        Button::make(__('Save'))
+                            ->type(Color::DEFAULT())
+                            ->icon('check')
+                            ->method('save')
+                    ),
+            ],
+            __('Other Information') => [
+                Layout::block(FarmlandEditOtherLayout::class)
+                    ->title(__('Other Information'))
+                    ->description(__('This information collects other farmland information'))
+                    ->commands(
+                        Button::make(__('Save'))
+                            ->type(Color::DEFAULT())
+                            ->icon('check')
+                            ->method('save')
+                    ),
+            ],
+        ];
+
         return [
-            Layout::block(FarmlandEditBasicLayout::class)
-                ->title(__('Basic Information'))
-                ->description(__('This information collects farmlands basic information')),
-
-            Layout::block(FarmlandEditMemberLayout::class)
-                ->title(__('Farmers'))
-                ->description(__('This information assigns the farmers to this farmland')),
-
-            Layout::block(FarmlandEditOtherLayout::class)
-                ->title(__('Other Information'))
-                ->description(__('This information collects other farmland information'))
-                ->commands(
-                    Button::make(__('Save'))
-                        ->type(Color::DEFAULT())
-                        ->icon('check')
-                        ->method('save')
-                ),
+            Layout::tabs($tabs)->activeTab(__('Basic Information')),
         ];
     }
 

--- a/database/seeders/Farmland/FarmlandSeeder.php
+++ b/database/seeders/Farmland/FarmlandSeeder.php
@@ -2,10 +2,11 @@
 
 namespace Database\Seeders\Farmland;
 
+use App\Models\Batch\Batch;
 use App\Models\Farmland\CropBuyer;
 use App\Models\Farmland\Farmland;
 use App\Models\Farmland\WateringSystem;
-use App\Models\User\Farmer\Farmer;
+use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Database\Seeder;
 
 class FarmlandSeeder extends Seeder
@@ -23,13 +24,19 @@ class FarmlandSeeder extends Seeder
             WateringSystemSeeder::class,
         ]);
 
-        Farmland::factory()->count(10)->create();
+        $batches = Batch::all();
+
+        Farmland::factory()
+            ->count(10)
+            ->sequence(fn (Sequence $sequence) => [
+                'batch_id' => $batches->get($sequence->index),
+            ])
+            ->create();
 
         $wateringSystems = WateringSystem::all();
         $cropBuyers = CropBuyer::all();
-        $farmers = Farmer::all();
 
-        Farmland::all()->each(function ($farmland) use ($wateringSystems, $cropBuyers, $farmers) {
+        Farmland::all()->each(function (Farmland $farmland) use ($wateringSystems, $cropBuyers) {
             $farmland->cropBuyers()->attach(
                 $cropBuyers->random(rand(1, $cropBuyers->count()))->pluck('id')->toArray()
             );
@@ -38,9 +45,7 @@ class FarmlandSeeder extends Seeder
                 $wateringSystems->random(rand(1, $wateringSystems->count()))->pluck('id')->toArray()
             );
 
-            $farmland->farmers()->attach(
-                $farmers->random(rand(1, $farmers->count()))->pluck('id')->toArray()
-            );
+            $farmland->farmers()->attach($farmland->batch->farmers->pluck('id')->toArray());
         });
     }
 }

--- a/tests/Feature/Orchid/Screens/Farmland/FarmlandEditScreenTest.php
+++ b/tests/Feature/Orchid/Screens/Farmland/FarmlandEditScreenTest.php
@@ -4,7 +4,6 @@ use App\Models\Farmland\CropBuyer;
 use App\Models\Farmland\Farmland;
 use App\Models\Farmland\WateringSystem;
 use App\Models\User\Admin\Admin;
-use App\Models\User\Farmer\Farmer;
 use Database\Seeders\Batch\BatchSeeder;
 use Database\Seeders\Crop\CropSeeder;
 use Database\Seeders\Farmland\FarmlandStatusSeeder;
@@ -76,7 +75,7 @@ it('creates a farmland from the create screen', function () {
         'hectares_size',
     );
 
-    $randomFarmerId = Farmer::all()->random()->id;
+    $randomFarmerId = $farmland->batch->farmers->first()->id;
     $randomCropBuyerId = CropBuyer::all()->random()->id;
     $randomWateringSystemId = WateringSystem::all()->random()->id;
 


### PR DESCRIPTION
### Proposed changes

- Fix farmland batch integrity by making sure that only farmland members are coming from the farmland's batch members.
  - All relevant seeders and tests have been updated to reflect this behavior.
- Fix an overlooked bug where the delete user always delete the user profile even if a reference error is caught.
